### PR TITLE
condition_parser: add "is" as alternative to "equals"

### DIFF
--- a/wayfire/lexer/symbol.hpp
+++ b/wayfire/lexer/symbol.hpp
@@ -17,7 +17,7 @@ static const std::set<std::string_view> SIGNALS = {"created"};
 /**
  * @brief Set of all the keywords recognized by the lexer.
  */
-static const std::set<std::string_view> KEYWORDS = {"equals", "contains", "if", "else", "then", "on", "all", "none"};
+static const std::set<std::string_view> KEYWORDS = {"is", "equals", "contains", "if", "else", "then", "on", "all", "none"};
 
 /**
  * @brief Set of all the operators recognized by the lexer.

--- a/wayfire/parser/condition_parser.cpp
+++ b/wayfire/parser/condition_parser.cpp
@@ -92,7 +92,7 @@ void condition_parser_t::_factor(lexer_t &lexer)
             throw std::runtime_error("Condition parser error. Expected keyword.");
         }
         auto keyword = get_string(_symbol.value);
-        if ((keyword != "equals") && (keyword != "contains"))
+        if ((keyword != "equals") && (keyword != "contains") && (keyword != "is"))
         {
             std::string error = "Condition parser error. Unsupported keyword. keyword: ";
             error.append(keyword);
@@ -107,7 +107,7 @@ void condition_parser_t::_factor(lexer_t &lexer)
         }
 
         // Create condition.
-        if (keyword == "equals")
+        if (keyword == "equals" || keyword == "is")
         {
             _root = std::make_shared<equals_condition_t>(identifier, _symbol.value);
         }


### PR DESCRIPTION
"is" is shorter and makes things more readable IMO