### PR TITLE
fix meson build missing head file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -76,6 +76,7 @@ headers_parser = [
 'wayfire/parser/action_parser.hpp',
 'wayfire/parser/condition_parser.hpp',
 'wayfire/parser/rule_parser.hpp',
+'wayfire/parser/lambda_rule_parser.hpp',
 ]
 
 headers_rule = [


### PR DESCRIPTION
lambda_rule_parser.hpp is lost

Signed-off-by: Chaojiang Luo <luochaojiang@uniontech.com>