### PR TITLE
lexer: Don't assume double if more than one dot in string

### DIFF
--- a/wayfire/lexer/literal.cpp
+++ b/wayfire/lexer/literal.cpp
@@ -3,6 +3,7 @@
 #include <ctype.h>
 #include <stdexcept>
 #include <string>
+#include <bits/stdc++.h>
 
 namespace wf
 {
@@ -86,7 +87,7 @@ variant_t parse_literal(const std::string &s)
     }
 
     // Deal with float or double here.
-    if (s.find('.') != std::string::npos)
+    if (std::count(std::begin(s), std::end(s), '.') == 1)
     {
         // Float or Double.
         if ((s.find('f') != std::string::npos) || (s.find('F') != std::string::npos))


### PR DESCRIPTION
This allows matches with more than one dot in the string, such as "org.gnome.Calculator". Previously, we were matching double if there were any dots in the string. This allows to match as a string type if there are more than one dot while preserving double for just one dot.