### PR TITLE
lexer: Don't use private gcc headers

### DIFF
--- a/wayfire/lexer/literal.cpp
+++ b/wayfire/lexer/literal.cpp
@@ -3,7 +3,7 @@
 #include <ctype.h>
 #include <stdexcept>
 #include <string>
-#include <bits/stdc++.h>
+#include <algorithm>
 
 namespace wf
 {


### PR DESCRIPTION
The headers in bits/ are actually specific to gcc and wont work with clang. Thanks to wayfire CI for catching this.