### PR TITLE
Fix build with GCC 13

### DIFF
--- a/wayfire/rule/lambda_rule.cpp
+++ b/wayfire/rule/lambda_rule.cpp
@@ -1,6 +1,7 @@
 #include "wayfire/rule/lambda_rule.hpp"
 #include "wayfire/condition/condition.hpp"
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <sstream>


### PR DESCRIPTION
GCC 13 (as usual for new compiler releases) shuffles around some internal includes so some are no longer transitively included.

See https://gnu.org/software/gcc/gcc-13/porting_to.html.

Bug: https://bugs.gentoo.org/895570
Closes: https://github.com/WayfireWM/wayfire/issues/1758