### PR TITLE
Fixed an error with compiling

### DIFF
--- a/wayfire/rule/lambda_rule.cpp
+++ b/wayfire/rule/lambda_rule.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <cstdint>
 
 namespace wf
 {


### PR DESCRIPTION
compiling wayfire on my machine which uses gcc 13.2.1 and meson 1.2.1 gave an error about a missing <cstdint> library on subprojects/wf-utils/wayfire/rule/lambda_rule.cpp, so i added that library and decided to pull request it.