### PR TITLE
condition_parser: handle SIGNAL type as an identifier

### DIFF
--- a/wayfire/parser/condition_parser.cpp
+++ b/wayfire/parser/condition_parser.cpp
@@ -80,7 +80,7 @@ void condition_parser_t::_factor(lexer_t &lexer)
 {
     _symbol = lexer.parse_symbol();
 
-    if (_symbol.type == symbol_t::type_t::IDENTIFIER)
+    if (_symbol.type == symbol_t::type_t::IDENTIFIER || _symbol.type == symbol_t::type_t::SIGNAL)
     {
         // Identifier.
         auto identifier = get_string(_symbol.value);


### PR DESCRIPTION
For example, if we have the criteria `maximized is true`: the code
currently will fail to recognize it, because maximized is a signal name.

@erikvanhamme This shouldn't break anything I hope?
