### PR TITLE
condition_parser: handle IDENTIFIER type when using 'contains'

### DIFF
--- a/wayfire/parser/condition_parser.cpp
+++ b/wayfire/parser/condition_parser.cpp
@@ -101,7 +101,7 @@ void condition_parser_t::_factor(lexer_t &lexer)
 
         // Value.
         _symbol = lexer.parse_symbol();
-        if (_symbol.type != symbol_t::type_t::LITERAL)
+        if (_symbol.type != symbol_t::type_t::LITERAL && _symbol.type != symbol_t::type_t::IDENTIFIER)
         {
             throw std::runtime_error("Condition parser error. Expected literal.");
         }


### PR DESCRIPTION
This fixes criteria such as `title contains Identifier`  by not throwing an error when an identifier could be expected.

Fixes [wayfire #2427](https://github.com/WayfireWM/wayfire/issues/2427).