### PR TITLE
fix contents of encapsulated strings being lexed

### DIFF
--- a/wayfire/lexer/lexer.cpp
+++ b/wayfire/lexer/lexer.cpp
@@ -179,7 +179,7 @@ variant_t lexer_t::_parse_encapsulated_literal(const std::string &s_bound, const
     auto length = (found_at + e_bound.size()) - _parse_position;
     auto literal_text = _text.substr(_parse_position, length);
     _parse_position += length;
-    return parse_literal(literal_text);
+    return variant_t(literal_text);
 }
 
 variant_t lexer_t::_parse_comment_literal()
@@ -187,7 +187,7 @@ variant_t lexer_t::_parse_comment_literal()
     // Comment literal runs from the comment sign to the end of the line.
     auto literal_text = _text.substr(_parse_position);
     _parse_position = _size;
-    return parse_literal(literal_text);
+    return variant_t(literal_text);
 }
 
 } // End namespace wf.


### PR DESCRIPTION
I encountered a similar issue as in #10 where creating a window rule like `on created if app_id is "f.exe" then maximize` would lead to the following error:
```
on created if app_id is "f.exe" then maximize
                        ^ Literal parser error. Text could not be converted to float. text:"f.exe"
```

This is because the lexer tries to parse the contents of encapsulated literals.

The only issue I can see with the solution is that it might not handle encapsulated character literals properly? Although I couldn't find a place where character literals are used.
Apart from that it doesn't really make sense to try to parse for example `"false"` as a boolean instead of a window with the title "false".

It might make sense to handle only literals encapsulated with `"` differently since at least the comments in `lexer.hpp` imply that it's supposed to be generic and there might eventually be a use case for encapsulated literals that aren't strings.
