### PR TITLE
Remove the _root->to_string() call to avoid unintended logging.

### DIFF
--- a/wayfire/parser/condition_parser.cpp
+++ b/wayfire/parser/condition_parser.cpp
@@ -45,8 +45,6 @@ std::shared_ptr<condition_t> condition_parser_t::parse(lexer_t &lexer)
         lexer.reverse();
     }
 
-    std::cout << _root->to_string() << std::endl;
-
     return _root;
 }
 


### PR DESCRIPTION
The line std::cout << _root->to_string() in condition_parser.cpp indirectly triggers debug logs like 'app_id contains variant: [type: string, value: ...]'

fix: https://github.com/WayfireWM/wayfire/issues/2789