### PR TITLE
fixed floating point/string detection

### DIFF
--- a/wayfire/lexer/literal.cpp
+++ b/wayfire/lexer/literal.cpp
@@ -87,7 +87,15 @@ variant_t parse_literal(const std::string &s)
     }
 
     // Deal with float or double here.
-    if (std::count(std::begin(s), std::end(s), '.') == 1)
+    //original if (std::count(std::begin(s), std::end(s), '.') == 1)
+    bool numeric_like = std::all_of(s.begin(), s.end(),
+    [](char c)
+    {
+        return std::isdigit(c) || c == '.' || c == '-' || c == '+' || c == 'f' || c == 'F';
+    });
+
+    if (numeric_like && std::count(s.begin(), s.end(), '.') == 1)
+
     {
         // Float or Double.
         if ((s.find('f') != std::string::npos) || (s.find('F') != std::string::npos))


### PR DESCRIPTION
I am updating the output detection logic in the window-rules plugin so it can detect display's make+mode+serial number in addition to the connector names (DP-1, HMDI-A-1).  This helps when connector names change especially when using a laptop dock connected to external monitors.

the view-action-interface.cpp file was choking on decimals used in the strings of the display names. 